### PR TITLE
support `--activate` flag to push inactive templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,41 +9,70 @@ Update coder templates automatically
 
 ## Inputs
 
-| Name | Description | Default |
-| ---- | ----------- | ------- |
-| `CODER_URL` | **Required** The url of coder (e.g. <https://dev.coder.com>). | - |
-| `CODER_TEMPLATE_NAME` | **Required** The name of template. | - |
-| `CODER_TEMPLATE_DIR` | The directory of template. |`CODER_TEMPLATE_NAME`|
-| `CODER_TEMPLATE_VERSION` | The version of template. | - |
-| `CODER_SESSION_TOKEN` | **Required** The session token of coder. | `secrets.CODER_SESSION_TOKEN` |
+| Name                      | Description                                                              | Default                       |
+| ------------------------- | ------------------------------------------------------------------------ | ----------------------------- |
+| `CODER_ACCESS_URL`        | **Required** The url of coder deployment (e.g. <https://dev.coder.com>). | -                             |
+| `CODER_SESSION_TOKEN`     | **Required** The session token of coder.                                 | `secrets.CODER_SESSION_TOKEN` |
+| `CODER_TEMPLATE_NAME`     | **Required** The name of template.                                       | -                             |
+| `CODER_TEMPLATE_DIR`      | The directory of template.                                               | `CODER_TEMPLATE_NAME`         |
+| `CODER_TEMPLATE_VERSION`  | The version of template.                                                 | -                             |
+| `CODER_TEMPLATE_ACTIVATE` | Activate the template after update.                                      | `true`                        |
 
-## Example
+## Examples
 
-```yaml
-name: Update Coder Template
+1. Update template with latest commit hash as version and activate it.
 
-on:
-  push:
-    branches:
-      - main
-    
-jobs:
-    update:
-        runs-on: ubuntu-latest
-        steps:
-        - name: Checkout
-          uses: actions/checkout@v3
-        - name: Get latest commit hash
-          id: latest_commit
-          run: echo "::set-output name=hash::$(git rev-parse --short HEAD)"
+   ```yaml
+   name: Update Coder Template
 
-        - name: Update Coder Template
-            uses: matifali/update-coder-template@latest
-            with:
-                CODER_TEMPLATE_NAME: "my-template"
-                CODER_TEMPLATE_DIR: "my-template"
-                CODER_URL: "https://dev.coder.com"
-                CODER_TEMPLATE_VERSION: "${{ steps.latest_commit.outputs.hash }}"
-                CODER_SESSION_TOKEN: ${{ secrets.CODER_SESSION_TOKEN }}
+   on:
+     push:
+       branches:
+         - main
 
-```
+   jobs:
+       update:
+           runs-on: ubuntu-latest
+           steps:
+           - name: Checkout
+             uses: actions/checkout@v3
+           - name: Get latest commit hash
+             id: latest_commit
+             run: echo "::set-output name=hash::$(git rev-parse --short HEAD)"
+
+           - name: Update Coder Template
+               uses: matifali/update-coder-template@latest
+               with:
+                   CODER_TEMPLATE_NAME: "my-template"
+                   CODER_TEMPLATE_DIR: "my-template"
+                   CODER_ACCESS_URL: "https://coder.example.com"
+                   CODER_TEMPLATE_VERSION: "${{ steps.latest_commit.outputs.hash }}"
+                   CODER_SESSION_TOKEN: ${{ secrets.CODER_SESSION_TOKEN }}
+   ```
+
+2. Update template with a random version name and don't activate it.
+
+   ```yaml
+   name: Update Coder Template
+
+   on:
+     push:
+       branches:
+         - main
+
+   jobs:
+       update:
+           runs-on: ubuntu-latest
+           steps:
+           - name: Checkout
+             uses: actions/checkout@v3
+
+           - name: Update Coder Template
+               uses: matifali/update-coder-template@latest
+               with:
+                   CODER_TEMPLATE_NAME: "my-template"
+                   CODER_TEMPLATE_DIR: "my-template"
+                   CODER_ACCESS_URL: "https://coder.example.com"
+                   CODER_TEMPLATE_ACTIVATE: "false"
+                   CODER_SESSION_TOKEN: ${{ secrets.CODER_SESSION_TOKEN }}
+   ```

--- a/action.yaml
+++ b/action.yaml
@@ -11,18 +11,22 @@ inputs:
   CODER_TEMPLATE_NAME:
     description: "Template name"
     required: true
-  CODER_URL:
-    description: "Coder URL (e.g. https://coder.example.com)"
+  CODER_ACCESS_URL:
+    description: "Coder access URL (e.g. https://coder.example.com)"
     required: true
   CODER_SESSION_TOKEN:
     description: "Coder session token"
     required: true
   CODER_TEMPLATE_DIR:
-    description: "Template directory name defaults to TEMPLATE_NAME"
+    description: "Template directory name (path to the directory containing the main.tf file default: TEMPLATE_NAME)"
     required: false
   CODER_TEMPLATE_VERSION:
     description: "Template version"
     required: false
+  CODER_TEMPLATE_ACTIVATE:
+    description: "Makes the current template active"
+    required: false
+    default: "true"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 runs:
@@ -34,3 +38,4 @@ runs:
     CODER_TEMPLATE_NAME: ${{ inputs.CODER_TEMPLATE_NAME }}
     CODER_TEMPLATE_DIR: ${{ inputs.CODER_TEMPLATE_DIR }}
     CODER_TEMPLATE_VERSION: ${{ inputs.CODER_TEMPLATE_VERSION }}
+    CODER_TEMPLATE_MAKE_ACTIVE: ${{ inputs.CODER_TEMPLATE_MAKE_ACTIVE }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,10 @@ set -e
 # Check if CODER_SESSION_TOKEN is set
 : "${CODER_SESSION_TOKEN:?Variable not set or empty}"
 
-echo "Pushing ${CODER_TEMPLATE_NAME} to ${CODER_URL}..."
+# Check if CODER_ACCESS_URL is set
+: "${CODER_ACCESS_URL:?Variable not set or empty}"
+
+echo "Pushing ${CODER_TEMPLATE_NAME} to ${CODER_ACCESS_URL}..."
 
 # if the CODRR_TEMPLATE_DIR is empty string, then use the TEMPLATE_NAME as the directory
 if [ -z "${CODER_TEMPLATE_DIR}" ]; then
@@ -14,7 +17,15 @@ fi
 # if the CODER_TEMPLATE_VERSION is empty string then let coder use a random name
 if [ -z "${CODER_TEMPLATE_VERSION}" ];
 then
-    coder templates push ${CODER_TEMPLATE_NAME} --directory ./${CODER_TEMPLATE_DIR} --url ${CODER_URL} --yes
+    echo "No version specified, using random name."
+    coder templates push ${CODER_TEMPLATE_NAME} --directory ./${CODER_TEMPLATE_DIR} --activate=${CODER_TEMPLATE_ACTIVATE} --yes
 else
-    coder templates push ${CODER_TEMPLATE_NAME} --directory ./${CODER_TEMPLATE_DIR} --url ${CODER_URL} --name ${CODER_TEMPLATE_VERSION} --yes
+    coder templates push ${CODER_TEMPLATE_NAME} --directory ./${CODER_TEMPLATE_DIR} --name ${CODER_TEMPLATE_VERSION} --activate=${CODER_TEMPLATE_ACTIVATE} --yes
+fi
+
+if [ "${CODER_TEMPLATE_ACTIVATE}" == "true" ];
+then
+    echo "Template ${CODER_TEMPLATE_NAME} pushed to ${CODER_ACCESS_URL} and activated."
+else
+    echo "Template ${CODER_TEMPLATE_NAME} pushed to ${CODER_ACCESS_URL}.
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,9 +18,19 @@ fi
 if [ -z "${CODER_TEMPLATE_VERSION}" ];
 then
     echo "No version specified, using random name."
-    coder templates push ${CODER_TEMPLATE_NAME} --directory ./${CODER_TEMPLATE_DIR} --activate=${CODER_TEMPLATE_ACTIVATE} --yes
+    if [ -z "${CODER_TEMPLATE_ACTIVATE}" ];
+    then
+        coder templates push ${CODER_TEMPLATE_NAME} --directory ./${CODER_TEMPLATE_DIR} --yes
+    else
+        coder templates push ${CODER_TEMPLATE_NAME} --directory ./${CODER_TEMPLATE_DIR} --activate=${CODER_TEMPLATE_ACTIVATE} --yes
+    fi
 else
-    coder templates push ${CODER_TEMPLATE_NAME} --directory ./${CODER_TEMPLATE_DIR} --name ${CODER_TEMPLATE_VERSION} --activate=${CODER_TEMPLATE_ACTIVATE} --yes
+    if [ -z "${CODER_TEMPLATE_ACTIVATE}" ];
+    then
+        coder templates push ${CODER_TEMPLATE_NAME} --directory ./${CODER_TEMPLATE_DIR} --name ${CODER_TEMPLATE_VERSION} --yes
+    else
+        coder templates push ${CODER_TEMPLATE_NAME} --directory ./${CODER_TEMPLATE_DIR} --name ${CODER_TEMPLATE_VERSION} --activate=${CODER_TEMPLATE_ACTIVATE} --yes
+    fi
 fi
 
 if [ "${CODER_TEMPLATE_ACTIVATE}" == "true" ];


### PR DESCRIPTION
Added a new input to push the new template versions as not-active.

Set `CODER_TEMPLATE_ACTIVATE=false` to use the new functionality