### PR TITLE
Two new optional inputs, `provisioner_tag` and `ignore_lockfile`, to enhance the configurability of the template push process

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,10 @@ inputs:
     description: "Dry run"
     required: false
     default: "false"
+  ignore_lockfile:
+    description: "Ignore warnings about not having a .terraform.lock.hcl file present in the template."
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -59,3 +63,4 @@ runs:
         CODER_TEMPLATE_MESSAGE: ${{ inputs.message }}
         CODER_TEMPLATE_DRY_RUN: ${{ inputs.dry_run }}
         CODER_PROVISIONER_TAG: ${{ inputs.provisioner_tag }}
+        CODER_IGNORE_LOCKFILE: ${{ inputs.ignore_lockfile }}

--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,10 @@ inputs:
     description: "update message"
     required: false
     default: "Updated via update-coder-template action"
+  organization:
+    description: "organization name"
+    required: false
+    default: ""
   dry_run:
     description: "Dry run"
     required: false
@@ -54,3 +58,4 @@ runs:
         CODER_TEMPLATE_ACTIVATE: ${{ inputs.activate }}
         CODER_TEMPLATE_MESSAGE: ${{ inputs.message }}
         CODER_TEMPLATE_DRY_RUN: ${{ inputs.dry_run }}
+        CODER_TEMPLATE_ORGANIZATION: ${{ inputs.organization }}

--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,10 @@ inputs:
     description: "Marks the current template version as active"
     required: false
     default: "true"
+  provisioner_tag:
+    description: "Add provisioner tag to the template, useful for identifying the template version in the Coder UI"
+    required: false
+    default: "-"
   message:
     description: "update message"
     required: false
@@ -54,3 +58,4 @@ runs:
         CODER_TEMPLATE_ACTIVATE: ${{ inputs.activate }}
         CODER_TEMPLATE_MESSAGE: ${{ inputs.message }}
         CODER_TEMPLATE_DRY_RUN: ${{ inputs.dry_run }}
+        CODER_PROVISIONER_TAG: ${{ inputs.provisioner_tag }}

--- a/push_template.sh
+++ b/push_template.sh
@@ -35,7 +35,7 @@ if [ "${CODER_TEMPLATE_ACTIVATE}" = "false" ]; then
 fi
 
 if [ "${CODER_IGNORE_LOCKFILE}" = "true" ]; then
-  push_command+=" --ignore-lockfile"
+  push_command+=" --ignore-lockfile=true"
 fi
 
 # Add confirmation flag to the push command

--- a/push_template.sh
+++ b/push_template.sh
@@ -19,6 +19,11 @@ if [ -n "${CODER_TEMPLATE_MESSAGE}" ]; then
   push_command+=" --message \"${CODER_TEMPLATE_MESSAGE}\""
 fi
 
+# Add organization to the push command if specified
+if [ -n "${CODER_TEMPLATE_ORGANIZATION}" ]; then
+  push_command+=" --org \"${CODER_TEMPLATE_ORGANIZATION}\""
+fi
+
 # Add version to the push command if specified
 if [ -n "${CODER_TEMPLATE_VERSION_NAME}" ]; then
   push_command+=" --name ${CODER_TEMPLATE_VERSION_NAME}"

--- a/push_template.sh
+++ b/push_template.sh
@@ -19,6 +19,11 @@ if [ -n "${CODER_TEMPLATE_MESSAGE}" ]; then
   push_command+=" --message \"${CODER_TEMPLATE_MESSAGE}\""
 fi
 
+# Add provisioner tag to the push command if specified
+if [ -n "${CODER_PROVISIONER_TAG}" ]; then
+  push_command+=" --provisioner-tag \"${CODER_PROVISIONER_TAG}\""
+fi
+
 # Add version to the push command if specified
 if [ -n "${CODER_TEMPLATE_VERSION_NAME}" ]; then
   push_command+=" --name ${CODER_TEMPLATE_VERSION_NAME}"

--- a/push_template.sh
+++ b/push_template.sh
@@ -21,7 +21,7 @@ fi
 
 # Add provisioner tag to the push command if specified
 if [ -n "${CODER_PROVISIONER_TAG}" ]; then
-  push_command+=" --provisioner-tag \"${CODER_PROVISIONER_TAG}\""
+  push_command+=" --provisioner-tag=\"${CODER_PROVISIONER_TAG}\""
 fi
 
 # Add version to the push command if specified
@@ -32,6 +32,10 @@ fi
 # Add activate flag to the push command if it is false
 if [ "${CODER_TEMPLATE_ACTIVATE}" = "false" ]; then
   push_command+=" --activate=false"
+fi
+
+if [ "${CODER_IGNORE_LOCKFILE}" = "true" ]; then
+  push_command+=" --ignore-lockfile"
 fi
 
 # Add confirmation flag to the push command


### PR DESCRIPTION
This pull request introduces two new optional inputs, `provisioner_tag` and `ignore_lockfile`, to enhance the configurability of the template push process. These inputs are integrated into the action's environment variables and the `push_template.sh` script to support additional functionality.

### Enhancements to `action.yaml` inputs:

* Added the `provisioner_tag` input to allow specifying a provisioner tag for identifying the template version in the Coder UI. Default value is `"-"`.
* Added the `ignore_lockfile` input to enable ignoring warnings about the absence of a `.terraform.lock.hcl` file. Default value is `"false"`.

### Updates to the `push_template.sh` script:

* Incorporated the `provisioner_tag` input into the push command to include a `--provisioner-tag` option if specified.
* Integrated the `ignore_lockfile` input into the push command to add a `--ignore-lockfile=true` flag when enabled.